### PR TITLE
change lumen style config getter to laravel style

### DIFF
--- a/src/AwsSnsServiceProvider.php
+++ b/src/AwsSnsServiceProvider.php
@@ -74,6 +74,6 @@ class AwsSnsServiceProvider extends ServiceProvider
      */
     protected function registerConfigs()
     {
-        app()->configure('aws-sns');
+        config('aws-sns');
     }
 }


### PR DESCRIPTION
### Potentially resolves issue Call to undefined method 'configure'
might be nice to support Lumen as well, but I think this is a necessary change to use the AwsSnsTopicChannel in Laravel